### PR TITLE
fix: atualizar endpoints de criação para rotas da API v2

### DIFF
--- a/nodes/MagnetCustomer/CustomerRequest.ts
+++ b/nodes/MagnetCustomer/CustomerRequest.ts
@@ -28,7 +28,7 @@ export async function customerRequest(
 					throw new Error('Parameter "fullname" is required for create operation');
 				}
 			requestMethod = 'POST';
-			endpoint = '/import/contacts';
+			endpoint = '/customers';
 			body = {
 				fullname: this.getNodeParameter('fullname', index),
 				email: this.getNodeParameter('email', index),

--- a/nodes/MagnetCustomer/DealRequest.ts
+++ b/nodes/MagnetCustomer/DealRequest.ts
@@ -26,7 +26,7 @@ export async function dealRequest(
 					throw new Error('Parameter "title" is required for create operation');
 				}
 			requestMethod = 'POST';
-			endpoint = '/import/deals';
+			endpoint = '/deals';
 			body = {
 				title: this.getNodeParameter('title', index),
 				description: this.getNodeParameter('description', index),

--- a/nodes/MagnetCustomer/LeadRequest.ts
+++ b/nodes/MagnetCustomer/LeadRequest.ts
@@ -27,7 +27,7 @@ export async function leadRequest(
 					throw new Error('Parameter "fullname" is required for create operation');
 				}
 			requestMethod = 'POST';
-			endpoint = '/import/leads';
+			endpoint = '/leads';
 			body = {
 				fullname: this.getNodeParameter('fullname', index),
 				email: this.getNodeParameter('email', index),

--- a/nodes/MagnetCustomer/OrganizationRequest.ts
+++ b/nodes/MagnetCustomer/OrganizationRequest.ts
@@ -28,7 +28,7 @@ export async function organizationRequest(
 					throw new Error('Parameter "fullname" is required for create operation');
 				}
 			requestMethod = 'POST';
-			endpoint = '/import/organizations';
+			endpoint = '/organizations';
 			body = {
 				fullname: this.getNodeParameter('fullname', index),
 				email: this.getNodeParameter('email', index),

--- a/nodes/MagnetCustomer/ProspectRequest.ts
+++ b/nodes/MagnetCustomer/ProspectRequest.ts
@@ -27,7 +27,7 @@ export async function prospectRequest(
 					throw new Error('Parameter "fullname" is required for create operation');
 				}
 			requestMethod = 'POST';
-			endpoint = '/import/prospects';
+			endpoint = '/prospects';
 			body = {
 				fullname: this.getNodeParameter('fullname', index),
 				email: this.getNodeParameter('email', index),

--- a/nodes/MagnetCustomer/TaskRequest.ts
+++ b/nodes/MagnetCustomer/TaskRequest.ts
@@ -25,7 +25,7 @@ export async function taskRequest(
 					throw new Error('Parameter "title" is required for create operation');
 				}
 			requestMethod = 'POST';
-			endpoint = '/import/tasks';
+			endpoint = '/tasks';
 			body = {
 				title: this.getNodeParameter('title', index),
 				observation: this.getNodeParameter('observation', index),


### PR DESCRIPTION
## Summary

- As rotas `/import/{entity}` foram removidas na platform-api (commit 3de3aed82)
- O nó N8N ainda usava essas rotas no operation `create`, causando **404 Not Found**
- Atualizado para usar as rotas corretas da API v2

## Mudanças

| Antes (404) | Depois (OK) |
|-------------|-------------|
| `/import/prospects` | `/prospects` |
| `/import/leads` | `/leads` |
| `/import/contacts` | `/customers` |
| `/import/deals` | `/deals` |
| `/import/organizations` | `/organizations` |
| `/import/tasks` | `/tasks` |

## Nota

As demais operações (get, getAll, update, delete, search) já usavam as rotas corretas. Apenas o `create` estava apontando para as rotas legadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)